### PR TITLE
Authentication with scheduled jobs

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -12,21 +12,28 @@ export const FILE_DATA_OBJECT_TYPE = 'http://www.semanticdesktop.org/ontologies/
 export const RDF_PREDICATE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
 export const REPEAT_FREQUENCY_PREDICATE = 'http://schema.org/repeatFrequency';
 
+export const BASIC_AUTH = 'https://www.w3.org/2019/wot/security#BasicSecurityScheme';
+export const OAUTH2 = 'https://www.w3.org/2019/wot/security#OAuth2SecurityScheme';
+
 export const PREFIXES = `
-  PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
-  PREFIX task: <http://redpencil.data.gift/vocabularies/tasks/>
-  PREFIX dct: <http://purl.org/dc/terms/>
-  PREFIX prov: <http://www.w3.org/ns/prov#>
-  PREFIX nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>
-  PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
-  PREFIX oslc: <http://open-services.net/ns/core#>
-  PREFIX cogs: <http://vocab.deri.ie/cogs#>
-  PREFIX adms: <http://www.w3.org/ns/adms#>
-  PREFIX schema: <http://schema.org/>
-  PREFIX nfo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#>
-  PREFIX hrvst: <http://lblod.data.gift/vocabularies/harvesting/>
-  PREFIX rpioHttp: <http://redpencil.data.gift/vocabularies/http/>
-  PREFIX dgftSec: <http://lblod.data.gift/vocabularies/security/>
+    PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+    PREFIX muAccount: <http://mu.semte.ch/vocabularies/account/>
+    PREFIX meb: <http://rdf.myexperiment.org/ontologies/base/>
+    PREFIX task: <http://redpencil.data.gift/vocabularies/tasks/>
+    PREFIX dct: <http://purl.org/dc/terms/>
+    PREFIX prov: <http://www.w3.org/ns/prov#>
+    PREFIX nie: <http://www.semanticdesktop.org/ontologies/2007/01/19/nie#>
+    PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+    PREFIX oslc: <http://open-services.net/ns/core#>
+    PREFIX cogs: <http://vocab.deri.ie/cogs#>
+    PREFIX adms: <http://www.w3.org/ns/adms#>
+    PREFIX schema: <http://schema.org/>
+    PREFIX nfo: <http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#>
+    PREFIX dgftOauth: <http://kanselarij.vo.data.gift/vocabularies/oauth-2.0-session/>
+    PREFIX hrvst: <http://lblod.data.gift/vocabularies/harvesting/>
+    PREFIX wotSec: <https://www.w3.org/2019/wot/security#>
+    PREFIX rpioHttp: <http://redpencil.data.gift/vocabularies/http/>
+    PREFIX dgftSec: <http://lblod.data.gift/vocabularies/security/>
 `;
 
 export const TASK_URI_PREFIX = 'http://redpencil.data.gift/id/task/';

--- a/lib/credential-helpers.js
+++ b/lib/credential-helpers.js
@@ -5,6 +5,33 @@ import { parseResult } from "../utils/parseResult";
 import { decrypt, encrypt } from "../utils/encrypt-credentials";
 
 /**
+ * Asks when there is authentication from the scheduledJob.
+ * This way we can run the encryption flow only when there is authentication.
+ * @param {String} scheduledJobUri
+ * @returns {Boolean} Boolean
+ */
+export async function hasAuth(scheduledJobUri) {
+  const askQuery = `
+  ${PREFIXES}
+  ASK WHERE {
+    GRAPH ?g {
+    ${sparqlEscapeUri(scheduledJobUri)} ^dct:isPartOf ?scheduledTasks.
+    ?scheduledTasks task:inputContainer ?inputContainer .
+    ?inputContainer task:hasHarvestingCollection ?sourceCollection .
+    ?sourceCollection dgftSec:targetAuthenticationConfiguration ?authenticationConfiguration.
+    ?authenticationConfiguration dgftSec:securityConfiguration/rdf:type ?secType .
+    VALUES ?secType {
+      ${sparqlEscapeUri(BASIC_AUTH)}
+      ${sparqlEscapeUri(OAUTH2)}
+    }
+   }
+  }
+  `;
+  const { boolean } = await query(askQuery);
+  return boolean
+}
+
+/**
  * Asks if the job is created from the scheduled Job
  * @param {String} scheduledJobUri
  * @returns {Boolean} Boolean

--- a/lib/credential-helpers.js
+++ b/lib/credential-helpers.js
@@ -108,126 +108,102 @@ export async function attachClonedAuthenticationConfiguraton(
   clonedCollectionUri,
   sourceCollectionUri
 ) {
-  const newAuthConfUri = `http://data.lblod.info/id/authentication-configurations/${uuid()}`;
-
   const authData = await getAuthData(sourceCollectionUri);
+  if (!authData)
+    return;
+  else if (authData.securityConfigurationType === BASIC_AUTH)
+    return attachClonedBasicAuthenticationConfiguraton(clonedCollectionUri, sourceCollectionUri, authData);
+  else if (authData.securityConfigurationType === OAUTH2)
+    return attachClonedOAuthAuthenticationConfiguraton(clonedCollectionUri, sourceCollectionUri, authData);
+  else
+    throw new Error(`Unsupported Security type ${authData.securityConfigurationType}`);
+}
 
-  const newOauth2SecurityScheme = `http://data.lblod.info/id/oauth2-security-schemes/${uuid()}`;
-  const newOauth2Creds = `http://data.lblod.info/id/oauth2-credentials/${uuid()}`;
+async function attachClonedBasicAuthenticationConfiguraton(
+  clonedCollectionUri,
+  sourceCollectionUri,
+  authData
+) {
+  const newAuthConfUri = `http://data.lblod.info/id/authentication-configurations/${uuid()}`;
   const newBasicSecurityScheme = `http://data.lblod.info/id/basic-security-schemes/${uuid()}`;
   const newBasicCreds = `http://data.lblod.info/id/basic-authentication-credentials/${uuid()}`;
-
-  let cloneQueryDecrypt;
-
-  if (!authData) {
-    return null;
-  } else if (authData.securityConfigurationType === BASIC_AUTH) {
-    const getBasicAuthInfo = `
+  const { user, pass } = await getBasicAuthInfo(sourceCollectionUri);
+  const decryptedUser = await decrypt(user);
+  const decryptedPass = await decrypt(pass);
+  await update(`
     ${PREFIXES}
-    SELECT DISTINCT ?user ?pass
-    WHERE {
-      ${sparqlEscapeUri(
-        sourceCollectionUri
-      )} dgftSec:targetAuthenticationConfiguration ?configuration .
+    INSERT {
       GRAPH ?g {
-        ?configuration dgftSec:secrets ?secrets .
-        ?secrets meb:username ?user ;
-                muAccount:password ?pass .
+        ${sparqlEscapeUri(clonedCollectionUri)}
+          dgftSec:targetAuthenticationConfiguration
+            ${sparqlEscapeUri(newAuthConfUri)} .
+        ${sparqlEscapeUri(newAuthConfUri)}
+          dgftSec:secrets ${sparqlEscapeUri(newBasicCreds)} .
+        ${sparqlEscapeUri(newBasicCreds)}
+          meb:username ${sparqlEscapeString(decryptedUser)} ;
+          muAccount:password ${sparqlEscapeString(decryptedPass)} .
+        ${sparqlEscapeUri(newAuthConfUri)}
+          dgftSec:securityConfiguration
+            ${sparqlEscapeUri(newBasicSecurityScheme)} .
+        ${sparqlEscapeUri(newBasicSecurityScheme)} ?srcConfP ?srcConfO .
       }
     }
-    `;
-    const { user, pass } = parseResult(await query(getBasicAuthInfo))[0];
-    cloneQueryDecrypt = `
-        ${PREFIXES}
-        INSERT {
-          GRAPH ?g {
-            ${sparqlEscapeUri(
-              clonedCollectionUri
-            )} dgftSec:targetAuthenticationConfiguration ${sparqlEscapeUri(
-      newAuthConfUri
-    )} .
-            ${sparqlEscapeUri(
-              newAuthConfUri
-            )} dgftSec:secrets ${sparqlEscapeUri(newBasicCreds)} .
-            ${sparqlEscapeUri(newBasicCreds)} meb:username ${sparqlEscapeString(await decrypt(user))} ;
-              muAccount:password ${sparqlEscapeString(await decrypt(pass))} .
-            ${sparqlEscapeUri(
-              newAuthConfUri
-            )} dgftSec:securityConfiguration ${sparqlEscapeUri(
-      newBasicSecurityScheme
-    )}.
-            ${sparqlEscapeUri(newBasicSecurityScheme)} ?srcConfP ?srcConfO.
-          }
-        }
-        WHERE {
-          GRAPH ?g {
-            ${sparqlEscapeUri(
-              authData.authenticationConfiguration
-            )} dgftSec:securityConfiguration ?srcConfg.
-            ?srcConfg ?srcConfP ?srcConfO.
-            ${sparqlEscapeUri(
-              authData.authenticationConfiguration
-            )} dgftSec:secrets ?srcSecrets.
-            ?srcSecrets  meb:username ?user ;
-              muAccount:password ?pass .
-          }
-        }`;
-  } else if (authData.securityConfigurationType === OAUTH2) {
-    const getOauth2Info = `
-  ${PREFIXES}
-  SELECT DISTINCT ?clientId ?clientSecret ?token ?flow
-  WHERE {
-    ${sparqlEscapeUri(
-      sourceCollectionUri
-    )} dgftSec:targetAuthenticationConfiguration ?configuration .
-    GRAPH ?g {
-      ?configuration dgftSec:secrets ?secrets .
-      ?secrets dgftOauth:clientId ?clientId ;
-        dgftOauth:clientSecret ?clientSecret .
-      ?configuration dgftSec:securityConfiguration ?scheme .
-      ?scheme wotSec:token ?token ;
-        wotSec:flow ?flow . }
-  }
-  `;
-    const { clientId, clientSecret, token, flow } = parseResult(await query(getOauth2Info))[0];
-    const decryptedClientId = await decrypt(clientId);
-    const decryptedClientSecret = await decrypt(clientSecret);
-    const decryptedToken = await decrypt(token);
-    const decryptedFlow = await decrypt(flow);
-    cloneQueryDecrypt = `
-      ${PREFIXES}
-      INSERT {
-        GRAPH ?g {
-          ${sparqlEscapeUri(clonedCollectionUri)}
-            dgftSec:targetAuthenticationConfiguration ${sparqlEscapeUri(newAuthConfUri)} .
-          ${sparqlEscapeUri(newAuthConfUri)}
-            a dgftSec:AuthenticationConfiguration ;
-            dgftSec:secrets ${sparqlEscapeUri(newOauth2Creds)} ;
-            dgftSec:securityConfiguration ${sparqlEscapeUri(newOauth2SecurityScheme)}.
-          ${sparqlEscapeUri(newOauth2Creds)}
-            a dgftSec:OAuth2Credentials ;
-            a dgftSec:Credentials ;
-            dgftOauth:clientId ${sparqlEscapeString(decryptedClientId)} ;
-            dgftOauth:clientSecret ${sparqlEscapeString(decryptedClientSecret)} .
-          ${sparqlEscapeUri(newOauth2SecurityScheme)}
-            a wotSec:SecurityScheme ;
-            a wotSec:OAuth2SecurityScheme ;
-            wotSec:token ${sparqlEscapeString(decryptedToken)} ;
-            wotSec:flow ${sparqlEscapeString(decryptedFlow)} .
-        }
+    WHERE {
+      GRAPH ?g {
+        ${sparqlEscapeUri(authData.authenticationConfiguration)}
+          dgftSec:securityConfiguration ?srcConfg .
+        ?srcConfg ?srcConfP ?srcConfO .
+        ${sparqlEscapeUri(authData.authenticationConfiguration)}
+          dgftSec:secrets ?srcSecrets .
+        ?srcSecrets
+          meb:username ?user ;
+          muAccount:password ?pass .
       }
-      WHERE {
-        GRAPH ?g {
-          ${sparqlEscapeUri(authData.authenticationConfiguration)}
-            a dgftSec:AuthenticationConfiguration .
-        }
-      }`;
-  } else {
-    throw new Error(`Unsupported Security type ${authData.securityConfigurationType}`);
-  }
+    }`);
+  return newAuthConfUri;
+}
 
-  await update(cloneQueryDecrypt);
-
+async function attachClonedOAuthAuthenticationConfiguraton(
+  clonedCollectionUri,
+  sourceCollectionUri,
+  authData
+) {
+  const newAuthConfUri = `http://data.lblod.info/id/authentication-configurations/${uuid()}`;
+  const newOauth2SecurityScheme = `http://data.lblod.info/id/oauth2-security-schemes/${uuid()}`;
+  const newOauth2Creds = `http://data.lblod.info/id/oauth2-credentials/${uuid()}`;
+  const { clientId, clientSecret, token, flow } = await getOauth2Info(sourceCollectionUri);
+  const decryptedClientId = await decrypt(clientId);
+  const decryptedClientSecret = await decrypt(clientSecret);
+  const decryptedToken = await decrypt(token);
+  const decryptedFlow = await decrypt(flow);
+  await update(`
+    ${PREFIXES}
+    INSERT {
+      GRAPH ?g {
+        ${sparqlEscapeUri(clonedCollectionUri)}
+          dgftSec:targetAuthenticationConfiguration ${sparqlEscapeUri(newAuthConfUri)} .
+        ${sparqlEscapeUri(newAuthConfUri)}
+          a dgftSec:AuthenticationConfiguration ;
+          dgftSec:secrets ${sparqlEscapeUri(newOauth2Creds)} ;
+          dgftSec:securityConfiguration ${sparqlEscapeUri(newOauth2SecurityScheme)} .
+        ${sparqlEscapeUri(newOauth2Creds)}
+          a dgftSec:OAuth2Credentials ;
+          a dgftSec:Credentials ;
+          dgftOauth:clientId ${sparqlEscapeString(decryptedClientId)} ;
+          dgftOauth:clientSecret ${sparqlEscapeString(decryptedClientSecret)} .
+        ${sparqlEscapeUri(newOauth2SecurityScheme)}
+          a wotSec:SecurityScheme ;
+          a wotSec:OAuth2SecurityScheme ;
+          wotSec:token ${sparqlEscapeString(decryptedToken)} ;
+          wotSec:flow ${sparqlEscapeString(decryptedFlow)} .
+      }
+    }
+    WHERE {
+      GRAPH ?g {
+        ${sparqlEscapeUri(authData.authenticationConfiguration)}
+          a dgftSec:AuthenticationConfiguration .
+      }
+    }`);
   return newAuthConfUri;
 }
 
@@ -236,118 +212,139 @@ export async function attachClonedAuthenticationConfiguraton(
  * @param {String} sourceCollectionUri
  */
  export async function updateSourceCollection(sourceCollectionUri) {
-  const getBasicAuthInfo = `
-  ${PREFIXES}
-  SELECT DISTINCT ?user ?pass
-  WHERE {
-    ${sparqlEscapeUri(
-      sourceCollectionUri
-    )} dgftSec:targetAuthenticationConfiguration ?configuration .
-    GRAPH ?g {
-      ?configuration dgftSec:secrets ?secrets .
-      ?secrets meb:username ?user ;
-              muAccount:password ?pass .
-    }
-  }
-  `;
-  const getOauth2Info = `
-  ${PREFIXES}
-  SELECT DISTINCT ?clientId ?clientSecret ?token ?flow
-  WHERE {
-    ${sparqlEscapeUri(
-      sourceCollectionUri
-    )} dgftSec:targetAuthenticationConfiguration ?configuration .
-    GRAPH ?g {
-      ?configuration dgftSec:secrets ?secrets .
-      ?secrets dgftOauth:clientId ?clientId ;
-        dgftOauth:clientSecret ?clientSecret .
-      ?configuration dgftSec:securityConfiguration ?scheme .
-      ?scheme wotSec:token ?token ;
-              wotSec:flow ?flow .
-    }
-  }
-  `;
-
   // Check for credential type
   const authData = await getAuthData(sourceCollectionUri);
 
   switch (authData.securityConfigurationType) {
     case BASIC_AUTH:
-      const { user, pass } = parseResult(await query(getBasicAuthInfo))[0];
-      const encryptBasicAuthQuery = `
-      ${PREFIXES}
-      DELETE {
-        GRAPH ?g {
-          ?configuration dgftSec:secrets ?secrets .
-          ?secrets meb:username ?user ;
-            muAccount:password ?pass .
-        }
-      }
-      INSERT {
-        GRAPH ?g {
-          ?configuration
-            dgftSec:secrets ?secrets ;
-            ext:authenticationSecretsEncrypted ${sparqlEscapeBool(true)} .
-          ?secrets meb:username ${sparqlEscapeString(await encrypt(user))} ;
-            muAccount:password ${sparqlEscapeString(await encrypt(pass))} .
-        }
-      }
-      WHERE {
-        ${sparqlEscapeUri(sourceCollectionUri)} dgftSec:targetAuthenticationConfiguration ?configuration .
-
-        GRAPH ?g {
-          ?configuration dgftSec:secrets ?secrets .
-          ?secrets meb:username ?user ;
-            muAccount:password ?pass .
-        }
-      }
-      `;
-      await update(encryptBasicAuthQuery);
+      await encryptBasicAuth(sourceCollectionUri);
       break;
     case OAUTH2:
-      const { clientId, clientSecret, token, flow } = parseResult(await query(getOauth2Info))[0];
-      const encryptOauth2Query = `
-      ${PREFIXES}
-      DELETE {
-        GRAPH ?g {
-          ?configuration dgftSec:secrets ?secrets .
-          ?secrets dgftOauth:clientId ?clientId ;
-            dgftOauth:clientSecret ?clientSecret .
-          ?configuration dgftSec:securityConfiguration ?scheme .
-          ?scheme wotSec:token ?token ;
-            wotSec:flow ?flow .
-        }
-      }
-      INSERT {
-        GRAPH ?g {
-          ?configuration
-            dgftSec:secrets ?secrets ;
-            ext:authenticationSecretsEncrypted ${sparqlEscapeBool(true)} .
-          ?secrets dgftOauth:clientId ${sparqlEscapeString(await encrypt(clientId))} ;
-            dgftOauth:clientSecret ${sparqlEscapeString(await encrypt(clientSecret))}  .
-          ?configuration dgftSec:securityConfiguration ?scheme .
-          ?scheme wotSec:token ${sparqlEscapeString(await encrypt(token))}  ;
-            wotSec:flow ${sparqlEscapeString(await encrypt(flow))}  .
-        }
-      }
-      WHERE {
-        ${sparqlEscapeUri(
-          sourceCollectionUri
-        )} dgftSec:targetAuthenticationConfiguration ?configuration .
-
-        GRAPH ?g {
-          ?configuration dgftSec:secrets ?secrets .
-          ?secrets dgftOauth:clientId ?clientId ;
-            dgftOauth:clientSecret ?clientSecret .
-          ?configuration dgftSec:securityConfiguration ?scheme .
-          ?scheme wotSec:token ?token ;
-            wotSec:flow ?flow .
-        }
-      }
-      `;
-      await update(encryptOauth2Query);
+      await encryptOauth2(sourceCollectionUri);
       break;
-    default:
-      return false;
   }
+}
+
+async function encryptBasicAuth(sourceCollectionUri) {
+  const { user, pass } = await getBasicAuthInfo(sourceCollectionUri);
+  const encryptedUser = await encrypt(user);
+  const encryptedPass = await encrypt(pass);
+  await update(`
+    ${PREFIXES}
+    DELETE {
+      GRAPH ?g {
+        ?configuration dgftSec:secrets ?secrets .
+        ?secrets
+          meb:username ?user ;
+          muAccount:password ?pass .
+      }
+    }
+    INSERT {
+      GRAPH ?g {
+        ?configuration
+          dgftSec:secrets ?secrets ;
+          ext:authenticationSecretsEncrypted ${sparqlEscapeBool(true)} .
+        ?secrets
+          meb:username ${sparqlEscapeString(encryptedUser)} ;
+          muAccount:password ${sparqlEscapeString(encryptedPass)} .
+      }
+    }
+    WHERE {
+      ${sparqlEscapeUri(sourceCollectionUri)}
+        dgftSec:targetAuthenticationConfiguration ?configuration .
+      GRAPH ?g {
+        ?configuration dgftSec:secrets ?secrets .
+        ?secrets
+          meb:username ?user ;
+          muAccount:password ?pass .
+      }
+    }`);
+}
+
+async function encryptOauth2(sourceCollectionUri) {
+  const { clientId, clientSecret, token, flow } = await getOauth2Info(sourceCollectionUri);
+  const encryptedClientId = await encrypt(clientId);
+  const encryptedClientSecret = await encrypt(clientSecret);
+  const encryptedToken = await encrypt(token);
+  const encryptedFlow = await encrypt(flow);
+  await update(`
+    ${PREFIXES}
+    DELETE {
+      GRAPH ?g {
+        ?configuration dgftSec:secrets ?secrets .
+        ?secrets
+          dgftOauth:clientId ?clientId ;
+          dgftOauth:clientSecret ?clientSecret .
+        ?configuration dgftSec:securityConfiguration ?scheme .
+        ?scheme
+          wotSec:token ?token ;
+          wotSec:flow ?flow .
+      }
+    }
+    INSERT {
+      GRAPH ?g {
+        ?configuration
+          dgftSec:secrets ?secrets ;
+          ext:authenticationSecretsEncrypted ${sparqlEscapeBool(true)} .
+        ?secrets
+          dgftOauth:clientId ${sparqlEscapeString(encryptedClientId)} ;
+          dgftOauth:clientSecret ${sparqlEscapeString(encryptedClientSecret)} .
+        ?configuration dgftSec:securityConfiguration ?scheme .
+        ?scheme
+          wotSec:token ${sparqlEscapeString(encryptedToken)} ;
+          wotSec:flow ${sparqlEscapeString(encryptedFlow)}  .
+      }
+    }
+    WHERE {
+      ${sparqlEscapeUri(sourceCollectionUri)}
+        dgftSec:targetAuthenticationConfiguration ?configuration .
+
+      GRAPH ?g {
+        ?configuration dgftSec:secrets ?secrets .
+        ?secrets dgftOauth:clientId ?clientId ;
+          dgftOauth:clientSecret ?clientSecret .
+        ?configuration dgftSec:securityConfiguration ?scheme .
+        ?scheme wotSec:token ?token ;
+          wotSec:flow ?flow .
+      }
+    }`);
+}
+
+async function getBasicAuthInfo(sourceCollectionUri) {
+  const getBasicAuthInfo = `
+    ${PREFIXES}
+    SELECT DISTINCT ?user ?pass
+    WHERE {
+      ${sparqlEscapeUri(sourceCollectionUri)}
+        dgftSec:targetAuthenticationConfiguration ?configuration .
+      GRAPH ?g {
+        ?configuration dgftSec:secrets ?secrets .
+        ?secrets
+          meb:username ?user ;
+          muAccount:password ?pass .
+      }
+    }
+    LIMIT 1`;
+  return parseResult(await query(getBasicAuthInfo))[0];
+}
+
+async function getOauth2Info(sourceCollectionUri) {
+  const getOauth2Info = `
+    ${PREFIXES}
+    SELECT DISTINCT ?clientId ?clientSecret ?token ?flow WHERE {
+      ${sparqlEscapeUri(sourceCollectionUri)}
+        dgftSec:targetAuthenticationConfiguration ?configuration .
+      GRAPH ?g {
+        ?configuration dgftSec:secrets ?secrets .
+        ?secrets
+          dgftOauth:clientId ?clientId ;
+          dgftOauth:clientSecret ?clientSecret .
+        ?configuration dgftSec:securityConfiguration ?scheme .
+        ?scheme
+          wotSec:token ?token ;
+          wotSec:flow ?flow .
+      }
+    }
+    LIMIT 1`;
+  return parseResult(await query(getOauth2Info))[0];
 }

--- a/lib/credential-helpers.js
+++ b/lib/credential-helpers.js
@@ -1,6 +1,6 @@
 import { PREFIXES, BASIC_AUTH, OAUTH2, JOB_TYPE, SCHEDULED_JOB_TYPE } from "../constants";
 import { querySudo as query, updateSudo as update } from "@lblod/mu-auth-sudo";
-import { sparqlEscapeUri, sparqlEscapeString, uuid } from "mu";
+import { sparqlEscapeUri, sparqlEscapeString, sparqlEscapeBool, uuid } from "mu";
 import { parseResult } from "../utils/parseResult";
 import { decrypt, encrypt } from "../utils/encrypt-credentials";
 
@@ -9,18 +9,27 @@ import { decrypt, encrypt } from "../utils/encrypt-credentials";
  * @param {String} scheduledJobUri
  * @returns {Boolean} Boolean
  */
-
-  export async function isNormalJobCreatedFromScheduledJob(scheduledJobUri) {
-    const askQuery = `
+export async function alreadyEncryptedAuthenticationConfiguration(scheduledJobUri) {
+  const askQuery = `
     ${PREFIXES}
     ASK WHERE {
-      ?job a ${sparqlEscapeUri(JOB_TYPE)} ;
-        dct:creator ${sparqlEscapeUri(scheduledJobUri)} .
+      BIND(${sparqlEscapeUri(scheduledJobUri)} AS ?job) .
+      ?job
+        a ${sparqlEscapeUri(SCHEDULED_JOB_TYPE)} .
+      ?task
+        dct:isPartOf ?job ;
+        task:inputContainer ?inputContainer .
+      ?inputContainer
+        task:hasHarvestingCollection ?harvestingCollection .
+      ?harvestingCollection
+        dgftSec:targetAuthenticationConfiguration ?authenticationConfiguration .
+      ?authenticationConfiguration
+        ext:authenticationSecretsEncrypted ${sparqlEscapeBool(true)} .
     }
-    `;
-    const { boolean } = await query(askQuery);
-    return boolean;
-  }
+  `;
+  const { boolean } = await query(askQuery);
+  return boolean;
+}
 
 /**
  * Gets the source collection uri from the scheduled job
@@ -265,7 +274,9 @@ export async function attachClonedAuthenticationConfiguraton(
       }
       INSERT {
         GRAPH ?g {
-          ?configuration dgftSec:secrets ?secrets .
+          ?configuration
+            dgftSec:secrets ?secrets ;
+            ext:authenticationSecretsEncrypted ${sparqlEscapeBool(true)} .
           ?secrets meb:username ${sparqlEscapeString(await encrypt(user))} ;
             muAccount:password ${sparqlEscapeString(await encrypt(pass))} .
         }
@@ -298,7 +309,9 @@ export async function attachClonedAuthenticationConfiguraton(
       }
       INSERT {
         GRAPH ?g {
-          ?configuration dgftSec:secrets ?secrets .
+          ?configuration
+            dgftSec:secrets ?secrets ;
+            ext:authenticationSecretsEncrypted ${sparqlEscapeBool(true)} .
           ?secrets dgftOauth:clientId ${sparqlEscapeString(await encrypt(clientId))} ;
             dgftOauth:clientSecret ${sparqlEscapeString(await encrypt(clientSecret))}  .
           ?configuration dgftSec:securityConfiguration ?scheme .

--- a/lib/credential-helpers.js
+++ b/lib/credential-helpers.js
@@ -12,21 +12,20 @@ import { decrypt, encrypt } from "../utils/encrypt-credentials";
  */
 export async function hasAuth(scheduledJobUri) {
   const askQuery = `
-  ${PREFIXES}
-  ASK WHERE {
-    GRAPH ?g {
-    ${sparqlEscapeUri(scheduledJobUri)} ^dct:isPartOf ?scheduledTasks.
-    ?scheduledTasks task:inputContainer ?inputContainer .
-    ?inputContainer task:hasHarvestingCollection ?sourceCollection .
-    ?sourceCollection dgftSec:targetAuthenticationConfiguration ?authenticationConfiguration.
-    ?authenticationConfiguration dgftSec:securityConfiguration/rdf:type ?secType .
-    VALUES ?secType {
-      ${sparqlEscapeUri(BASIC_AUTH)}
-      ${sparqlEscapeUri(OAUTH2)}
-    }
-   }
-  }
-  `;
+    ${PREFIXES}
+    ASK WHERE {
+      GRAPH ?g {
+        ${sparqlEscapeUri(scheduledJobUri)} ^dct:isPartOf ?scheduledTasks.
+        ?scheduledTasks task:inputContainer ?inputContainer .
+        ?inputContainer task:hasHarvestingCollection ?sourceCollection .
+        ?sourceCollection dgftSec:targetAuthenticationConfiguration ?authenticationConfiguration .
+        ?authenticationConfiguration dgftSec:securityConfiguration/rdf:type ?secType .
+        VALUES ?secType {
+          ${sparqlEscapeUri(BASIC_AUTH)}
+          ${sparqlEscapeUri(OAUTH2)}
+        }
+      }
+    }`;
   const { boolean } = await query(askQuery);
   return boolean
 }
@@ -52,8 +51,7 @@ export async function alreadyEncryptedAuthenticationConfiguration(scheduledJobUr
         dgftSec:targetAuthenticationConfiguration ?authenticationConfiguration .
       ?authenticationConfiguration
         ext:authenticationSecretsEncrypted ${sparqlEscapeBool(true)} .
-    }
-  `;
+    }`;
   const { boolean } = await query(askQuery);
   return boolean;
 }
@@ -65,13 +63,13 @@ export async function alreadyEncryptedAuthenticationConfiguration(scheduledJobUr
  */
  export async function getCollectionFromJob(jobUri) {
   const getCollectionQuery = `
-  ${PREFIXES}
-  SELECT DISTINCT ?collectionUri WHERE {
-    ${sparqlEscapeUri(jobUri)} ^dct:isPartOf ?scheduledTasks.
-    ?scheduledTasks task:inputContainer ?inputContainer .
-    ?inputContainer task:hasHarvestingCollection ?collectionUri .
-  }
-  `
+    ${PREFIXES}
+    SELECT ?collectionUri WHERE {
+      ${sparqlEscapeUri(jobUri)} ^dct:isPartOf ?scheduledTasks .
+      ?scheduledTasks task:inputContainer ?inputContainer .
+      ?inputContainer task:hasHarvestingCollection ?collectionUri .
+    }
+    LIMIT 1`;
   return parseResult(await query(getCollectionQuery))[0];
 }
 
@@ -81,24 +79,19 @@ export async function alreadyEncryptedAuthenticationConfiguration(scheduledJobUr
  * @param {String} collectionUri
  * @returns {Object} { securityConfigurationType, authenticationConfiguration }
  */
-
 async function getAuthData(collectionUri) {
   const credentialsTypeQuery = `
     ${PREFIXES}
-
     SELECT DISTINCT ?securityConfigurationType ?authenticationConfiguration WHERE {
-        ${sparqlEscapeUri(
-          collectionUri
-        )} dgftSec:targetAuthenticationConfiguration ?authenticationConfiguration .
-        ?authenticationConfiguration dgftSec:securityConfiguration/rdf:type ?securityConfigurationType .
-        VALUES ?securityConfigurationType {
-          ${sparqlEscapeUri(BASIC_AUTH)}
-          ${sparqlEscapeUri(OAUTH2)}
+      ${sparqlEscapeUri(collectionUri)} dgftSec:targetAuthenticationConfiguration ?authenticationConfiguration .
+      ?authenticationConfiguration dgftSec:securityConfiguration/rdf:type ?securityConfigurationType .
+      VALUES ?securityConfigurationType {
+        ${sparqlEscapeUri(BASIC_AUTH)}
+        ${sparqlEscapeUri(OAUTH2)}
       }
     }
-  `;
-  const authData = parseResult(await query(credentialsTypeQuery))[0];
-  return authData;
+    LIMIT 1`;
+  return parseResult(await query(credentialsTypeQuery))[0];
 }
 
 /**

--- a/lib/credential-helpers.js
+++ b/lib/credential-helpers.js
@@ -223,7 +223,6 @@ export async function attachClonedAuthenticationConfiguraton(
  * @param {String} sourceCollectionUri
  */
  export async function updateSourceCollection(sourceCollectionUri) {
-  let authData;
   const getBasicAuthInfo = `
   ${PREFIXES}
   SELECT DISTINCT ?user ?pass
@@ -257,8 +256,7 @@ export async function attachClonedAuthenticationConfiguraton(
   `;
 
   // Check for credential type
-  if (!authData)
-    authData = await getAuthData(sourceCollectionUri);
+  const authData = await getAuthData(sourceCollectionUri);
 
   switch (authData.securityConfigurationType) {
     case BASIC_AUTH:

--- a/lib/credential-helpers.js
+++ b/lib/credential-helpers.js
@@ -5,8 +5,8 @@ import { parseResult } from "../utils/parseResult";
 import { decrypt, encrypt } from "../utils/encrypt-credentials";
 
 /**
- * Asks when there is authentication from the scheduledJob.
- * This way we can run the encryption flow only when there is authentication.
+ * Asks if there is authentication on the scheduled job. This way we can run
+ * the encryption flow only when there is authentication.
  * @param {String} scheduledJobUri
  * @returns {Boolean} Boolean
  */
@@ -32,7 +32,7 @@ export async function hasAuth(scheduledJobUri) {
 }
 
 /**
- * Asks if the job is created from the scheduled Job
+ * Asks if the job is created by the scheduled job service.
  * @param {String} scheduledJobUri
  * @returns {Boolean} Boolean
  */
@@ -59,7 +59,7 @@ export async function alreadyEncryptedAuthenticationConfiguration(scheduledJobUr
 }
 
 /**
- * Gets the source collection uri from the scheduled job
+ * Gets the source collection URI from the scheduled job.
  * @param {String} jobUri
  * @returns {Object}
  */
@@ -76,7 +76,8 @@ export async function alreadyEncryptedAuthenticationConfiguration(scheduledJobUr
 }
 
 /**
- * Gets securityConfigurationType and authenticationConfiguration from CollectionUri
+ * Gets securityConfigurationType and authenticationConfiguration from
+ * CollectionUri.
  * @param {String} collectionUri
  * @returns {Object} { securityConfigurationType, authenticationConfiguration }
  */

--- a/lib/credential-helpers.js
+++ b/lib/credential-helpers.js
@@ -169,46 +169,38 @@ export async function attachClonedAuthenticationConfiguraton(
   }
   `;
     const { clientId, clientSecret, token, flow } = parseResult(await query(getOauth2Info))[0];
+    const decryptedClientId = await decrypt(clientId);
+    const decryptedClientSecret = await decrypt(clientSecret);
+    const decryptedToken = await decrypt(token);
+    const decryptedFlow = await decrypt(flow);
     cloneQueryDecrypt = `
-    ${PREFIXES}
-    INSERT {
-      GRAPH ?g {
-        ${sparqlEscapeUri(
-          clonedCollectionUri
-        )} dgftSec:targetAuthenticationConfiguration ${sparqlEscapeUri(
-  newAuthConfUri
-)} .
-        ${sparqlEscapeUri(
-          newAuthConfUri
-        )} dgftSec:secrets ${sparqlEscapeUri(newOauth2Creds)} .
-        ${sparqlEscapeUri(newOauth2Creds)} dgftOauth:clientId ${sparqlEscapeString(await decrypt(clientId))} ;
-          dgftOauth:clientSecret ${sparqlEscapeString(await decrypt(clientSecret))} .
-        ${sparqlEscapeUri(
-          newAuthConfUri
-        )} dgftSec:securityConfiguration ${sparqlEscapeUri(
-  newOauth2SecurityScheme
-)}.
-        ${sparqlEscapeUri(newOauth2SecurityScheme)} dgftSec:securityConfiguration ?scheme .
-        ?scheme wotSec:token ${sparqlEscapeString(await decrypt(token))} ;
-        wotSec:flow ${sparqlEscapeString(await decrypt(flow))} .
+      ${PREFIXES}
+      INSERT {
+        GRAPH ?g {
+          ${sparqlEscapeUri(clonedCollectionUri)}
+            dgftSec:targetAuthenticationConfiguration ${sparqlEscapeUri(newAuthConfUri)} .
+          ${sparqlEscapeUri(newAuthConfUri)}
+            a dgftSec:AuthenticationConfiguration ;
+            dgftSec:secrets ${sparqlEscapeUri(newOauth2Creds)} ;
+            dgftSec:securityConfiguration ${sparqlEscapeUri(newOauth2SecurityScheme)}.
+          ${sparqlEscapeUri(newOauth2Creds)}
+            a dgftSec:OAuth2Credentials ;
+            a dgftSec:Credentials ;
+            dgftOauth:clientId ${sparqlEscapeString(decryptedClientId)} ;
+            dgftOauth:clientSecret ${sparqlEscapeString(decryptedClientSecret)} .
+          ${sparqlEscapeUri(newOauth2SecurityScheme)}
+            a wotSec:SecurityScheme ;
+            a wotSec:OAuth2SecurityScheme ;
+            wotSec:token ${sparqlEscapeString(decryptedToken)} ;
+            wotSec:flow ${sparqlEscapeString(decryptedFlow)} .
+        }
       }
-    }
-    WHERE {
-      GRAPH ?g {
-        ${sparqlEscapeUri(
-          authData.authenticationConfiguration
-        )} dgftSec:securityConfiguration ?srcConfg.
-        ?srcConfg ?srcConfP ?srcConfO.
-        ${sparqlEscapeUri(
-          authData.authenticationConfiguration
-        )} dgftSec:secrets ?srcSecrets.
-        ?srcSecrets dgftOauth:clientId ?clientId ;
-          dgftOauth:clientSecret ?clientSecret .
-        ?srcConfig dgftSec:securityConfiguration ?scheme .
-        ?scheme wotSec:token ?token ;
-                wotSec:flow ?flow .
-      }
-    }`;
+      WHERE {
+        GRAPH ?g {
+          ${sparqlEscapeUri(authData.authenticationConfiguration)}
+            a dgftSec:AuthenticationConfiguration .
+        }
+      }`;
   } else {
     throw new Error(`Unsupported Security type ${authData.securityConfigurationType}`);
   }

--- a/lib/credential-helpers.js
+++ b/lib/credential-helpers.js
@@ -1,0 +1,110 @@
+import { PREFIXES, BASIC_AUTH, OAUTH2 } from "../constants";
+import { querySudo as query, updateSudo as update } from "@lblod/mu-auth-sudo";
+import { sparqlEscapeUri, uuid } from "mu";
+import { parseResult } from "../utils/parseResult";
+
+/**
+ * Gets securityConfigurationType and authenticationConfiguration from CollectionUri
+ * @param {String} collectionUri
+ * @returns {Object} { securityConfigurationType, authenticationConfiguration }
+ */
+
+async function getAuthData(collectionUri) {
+  const credentialsTypeQuery = `
+    ${PREFIXES}
+
+    SELECT DISTINCT ?securityConfigurationType ?authenticationConfiguration WHERE {
+        ${sparqlEscapeUri(
+          collectionUri
+        )} dgftSec:targetAuthenticationConfiguration ?authenticationConfiguration .
+        ?authenticationConfiguration dgftSec:securityConfiguration/rdf:type ?securityConfigurationType .
+        VALUES ?securityConfigurationType {
+          ${sparqlEscapeUri(BASIC_AUTH)}
+          ${sparqlEscapeUri(OAUTH2)}
+      }
+    }
+  `;
+  const authData = parseResult(await query(credentialsTypeQuery))[0];
+  return authData;
+}
+
+/**
+ * Inserting the `AuthenticationConfiguration` from the source collection to cloned collection to allow the download step from `download-url-service`.
+ * This is making a deepcopy of the authentication configuration from collection to collection.
+ *
+ * @param {String} clonedCollectionUri cloned collection
+ * @param {String} sourceCollectionUri source collection
+ * @returns newAuthConfUri
+ *
+ * Note: `AuthenticationConfiguration` credentials will be removed in the `download-url-service`.
+ */
+export async function attachClonedAuthenticationConfiguraton(
+  clonedCollectionUri,
+  sourceCollectionUri
+) {
+  const newAuthConfUri = `http://data.lblod.info/id/authentication-configurations/${uuid()}`;
+
+  const authData = await getAuthData(sourceCollectionUri);
+
+  const newOauth2SecurityScheme = `http://data.lblod.info/id/oauth2-security-schemes/${uuid()}`;
+  const newOauth2Creds = `http://data.lblod.info/id/oauth2-credentials/${uuid()}`;
+  const newBasicSecurityScheme = `http://data.lblod.info/id/basic-security-schemes/${uuid()}`;
+  const newBasicCreds = `http://data.lblod.info/id/basic-authentication-credentials/${uuid()}`;
+
+  let cloneQuery;
+
+  if (!authData) {
+    return null;
+  } else if (authData.securityConfigurationType === BASIC_AUTH) {
+    cloneQuery = `
+    ${PREFIXES}
+    INSERT {
+      GRAPH ?g {
+        ${sparqlEscapeUri(clonedCollectionUri)} dgftSec:targetAuthenticationConfiguration ${sparqlEscapeUri(newAuthConfUri)} .
+        ${sparqlEscapeUri(newAuthConfUri)} dgftSec:secrets ${sparqlEscapeUri(newBasicCreds)} .
+        ${sparqlEscapeUri(newBasicCreds)} meb:username ?user ;
+          muAccount:password ?pass .
+        ${sparqlEscapeUri(newAuthConfUri)} dgftSec:securityConfiguration ${sparqlEscapeUri(newBasicSecurityScheme)}.
+        ${sparqlEscapeUri(newBasicSecurityScheme)} ?srcConfP ?srcConfO.
+      }
+    }
+    WHERE {
+      GRAPH ?g {
+        ${sparqlEscapeUri(authData.authenticationConfiguration)} dgftSec:securityConfiguration ?srcConfg.
+        ?srcConfg ?srcConfP ?srcConfO.
+        ${sparqlEscapeUri(authData.authenticationConfiguration)} dgftSec:secrets ?srcSecrets.
+        ?srcSecrets  meb:username ?user ;
+          muAccount:password ?pass .
+      }
+    }`;
+  } else if (authData.securityConfigurationType === OAUTH2) {
+    cloneQuery = `
+    ${PREFIXES}
+    INSERT {
+      GRAPH ?g {
+        ${sparqlEscapeUri(clonedCollectionUri)} dgftSec:targetAuthenticationConfiguration ${sparqlEscapeUri(newAuthConfUri)} .
+        ${sparqlEscapeUri(newAuthConfUri)} dgftSec:secrets ${sparqlEscapeUri(newOauth2Creds)} .
+        ${sparqlEscapeUri(newOauth2Creds)} dgftOauth:clientId ?clientId ;
+          dgftOauth:clientSecret ?clientSecret .
+        ${sparqlEscapeUri(newAuthConfUri)} dgftSec:securityConfiguration ${sparqlEscapeUri(newOauth2SecurityScheme)}.
+        ${sparqlEscapeUri(newOauth2SecurityScheme)} ?srcConfP ?srcConfO.
+      }
+    }
+    WHERE {
+      GRAPH ?g {
+        ${sparqlEscapeUri(authData.authenticationConfiguration)} dgftSec:securityConfiguration ?srcConfg.
+        ?srcConfg ?srcConfP ?srcConfO.
+        ${sparqlEscapeUri(authData.authenticationConfiguration)} dgftSec:secrets ?srcSecrets.
+        ?srcSecrets dgftOauth:clientId ?clientId ;
+          dgftOauth:clientSecret ?clientSecret .
+          OPTIONAL { ?srcConfig dgftOauth:resource ?resource . }
+      }
+    }`;
+  } else {
+    throw new Error(`Unsupported Security type ${authData.securityConfigurationType}`);
+  }
+
+  await update(cloneQuery);
+
+  return newAuthConfUri;
+}

--- a/lib/credential-helpers.js
+++ b/lib/credential-helpers.js
@@ -1,7 +1,43 @@
-import { PREFIXES, BASIC_AUTH, OAUTH2 } from "../constants";
+import { PREFIXES, BASIC_AUTH, OAUTH2, JOB_TYPE, SCHEDULED_JOB_TYPE } from "../constants";
 import { querySudo as query, updateSudo as update } from "@lblod/mu-auth-sudo";
-import { sparqlEscapeUri, uuid } from "mu";
+import { sparqlEscapeUri, sparqlEscapeString, uuid } from "mu";
 import { parseResult } from "../utils/parseResult";
+import { decrypt, encrypt } from "../utils/encrypt-credentials";
+
+/**
+ * Asks if the job is created from the scheduled Job
+ * @param {String} scheduledJobUri
+ * @returns {Boolean} Boolean
+ */
+
+  export async function isNormalJobCreatedFromScheduledJob(scheduledJobUri) {
+    const askQuery = `
+    ${PREFIXES}
+    ASK WHERE {
+      ?job a ${sparqlEscapeUri(JOB_TYPE)} ;
+        dct:creator ${sparqlEscapeUri(scheduledJobUri)} .
+    }
+    `;
+    const { boolean } = await query(askQuery);
+    return boolean;
+  }
+
+/**
+ * Gets the source collection uri from the scheduled job
+ * @param {String} jobUri
+ * @returns {Object}
+ */
+ export async function getCollectionFromJob(jobUri) {
+  const getCollectionQuery = `
+  ${PREFIXES}
+  SELECT DISTINCT ?collectionUri WHERE {
+    ${sparqlEscapeUri(jobUri)} ^dct:isPartOf ?scheduledTasks.
+    ?scheduledTasks task:inputContainer ?inputContainer .
+    ?inputContainer task:hasHarvestingCollection ?collectionUri .
+  }
+  `
+  return parseResult(await query(getCollectionQuery))[0];
+}
 
 /**
  * Gets securityConfigurationType and authenticationConfiguration from CollectionUri
@@ -51,60 +87,243 @@ export async function attachClonedAuthenticationConfiguraton(
   const newBasicSecurityScheme = `http://data.lblod.info/id/basic-security-schemes/${uuid()}`;
   const newBasicCreds = `http://data.lblod.info/id/basic-authentication-credentials/${uuid()}`;
 
-  let cloneQuery;
+  let cloneQueryDecrypt;
 
   if (!authData) {
     return null;
   } else if (authData.securityConfigurationType === BASIC_AUTH) {
-    cloneQuery = `
+    const getBasicAuthInfo = `
     ${PREFIXES}
-    INSERT {
+    SELECT DISTINCT ?user ?pass
+    WHERE {
+      ${sparqlEscapeUri(
+        sourceCollectionUri
+      )} dgftSec:targetAuthenticationConfiguration ?configuration .
       GRAPH ?g {
-        ${sparqlEscapeUri(clonedCollectionUri)} dgftSec:targetAuthenticationConfiguration ${sparqlEscapeUri(newAuthConfUri)} .
-        ${sparqlEscapeUri(newAuthConfUri)} dgftSec:secrets ${sparqlEscapeUri(newBasicCreds)} .
-        ${sparqlEscapeUri(newBasicCreds)} meb:username ?user ;
-          muAccount:password ?pass .
-        ${sparqlEscapeUri(newAuthConfUri)} dgftSec:securityConfiguration ${sparqlEscapeUri(newBasicSecurityScheme)}.
-        ${sparqlEscapeUri(newBasicSecurityScheme)} ?srcConfP ?srcConfO.
+        ?configuration dgftSec:secrets ?secrets .
+        ?secrets meb:username ?user ;
+                muAccount:password ?pass .
       }
     }
-    WHERE {
-      GRAPH ?g {
-        ${sparqlEscapeUri(authData.authenticationConfiguration)} dgftSec:securityConfiguration ?srcConfg.
-        ?srcConfg ?srcConfP ?srcConfO.
-        ${sparqlEscapeUri(authData.authenticationConfiguration)} dgftSec:secrets ?srcSecrets.
-        ?srcSecrets  meb:username ?user ;
-          muAccount:password ?pass .
-      }
-    }`;
+    `;
+    const { user, pass } = parseResult(await query(getBasicAuthInfo))[0];
+    cloneQueryDecrypt = `
+        ${PREFIXES}
+        INSERT {
+          GRAPH ?g {
+            ${sparqlEscapeUri(
+              clonedCollectionUri
+            )} dgftSec:targetAuthenticationConfiguration ${sparqlEscapeUri(
+      newAuthConfUri
+    )} .
+            ${sparqlEscapeUri(
+              newAuthConfUri
+            )} dgftSec:secrets ${sparqlEscapeUri(newBasicCreds)} .
+            ${sparqlEscapeUri(newBasicCreds)} meb:username ${sparqlEscapeString(await decrypt(user))} ;
+              muAccount:password ${sparqlEscapeString(await decrypt(pass))} .
+            ${sparqlEscapeUri(
+              newAuthConfUri
+            )} dgftSec:securityConfiguration ${sparqlEscapeUri(
+      newBasicSecurityScheme
+    )}.
+            ${sparqlEscapeUri(newBasicSecurityScheme)} ?srcConfP ?srcConfO.
+          }
+        }
+        WHERE {
+          GRAPH ?g {
+            ${sparqlEscapeUri(
+              authData.authenticationConfiguration
+            )} dgftSec:securityConfiguration ?srcConfg.
+            ?srcConfg ?srcConfP ?srcConfO.
+            ${sparqlEscapeUri(
+              authData.authenticationConfiguration
+            )} dgftSec:secrets ?srcSecrets.
+            ?srcSecrets  meb:username ?user ;
+              muAccount:password ?pass .
+          }
+        }`;
   } else if (authData.securityConfigurationType === OAUTH2) {
-    cloneQuery = `
+    const getOauth2Info = `
+  ${PREFIXES}
+  SELECT DISTINCT ?clientId ?clientSecret ?token ?flow
+  WHERE {
+    ${sparqlEscapeUri(
+      sourceCollectionUri
+    )} dgftSec:targetAuthenticationConfiguration ?configuration .
+    GRAPH ?g {
+      ?configuration dgftSec:secrets ?secrets .
+      ?secrets dgftOauth:clientId ?clientId ;
+        dgftOauth:clientSecret ?clientSecret .
+      ?configuration dgftSec:securityConfiguration ?scheme .
+      ?scheme wotSec:token ?token ;
+        wotSec:flow ?flow . }
+  }
+  `;
+    const { clientId, clientSecret, token, flow } = parseResult(await query(getOauth2Info))[0];
+    cloneQueryDecrypt = `
     ${PREFIXES}
     INSERT {
       GRAPH ?g {
-        ${sparqlEscapeUri(clonedCollectionUri)} dgftSec:targetAuthenticationConfiguration ${sparqlEscapeUri(newAuthConfUri)} .
-        ${sparqlEscapeUri(newAuthConfUri)} dgftSec:secrets ${sparqlEscapeUri(newOauth2Creds)} .
-        ${sparqlEscapeUri(newOauth2Creds)} dgftOauth:clientId ?clientId ;
-          dgftOauth:clientSecret ?clientSecret .
-        ${sparqlEscapeUri(newAuthConfUri)} dgftSec:securityConfiguration ${sparqlEscapeUri(newOauth2SecurityScheme)}.
-        ${sparqlEscapeUri(newOauth2SecurityScheme)} ?srcConfP ?srcConfO.
+        ${sparqlEscapeUri(
+          clonedCollectionUri
+        )} dgftSec:targetAuthenticationConfiguration ${sparqlEscapeUri(
+  newAuthConfUri
+)} .
+        ${sparqlEscapeUri(
+          newAuthConfUri
+        )} dgftSec:secrets ${sparqlEscapeUri(newOauth2Creds)} .
+        ${sparqlEscapeUri(newOauth2Creds)} dgftOauth:clientId ${sparqlEscapeString(await decrypt(clientId))} ;
+          dgftOauth:clientSecret ${sparqlEscapeString(await decrypt(clientSecret))} .
+        ${sparqlEscapeUri(
+          newAuthConfUri
+        )} dgftSec:securityConfiguration ${sparqlEscapeUri(
+  newOauth2SecurityScheme
+)}.
+        ${sparqlEscapeUri(newOauth2SecurityScheme)} dgftSec:securityConfiguration ?scheme .
+        ?scheme wotSec:token ${sparqlEscapeString(await decrypt(token))} ;
+        wotSec:flow ${sparqlEscapeString(await decrypt(flow))} .
       }
     }
     WHERE {
       GRAPH ?g {
-        ${sparqlEscapeUri(authData.authenticationConfiguration)} dgftSec:securityConfiguration ?srcConfg.
+        ${sparqlEscapeUri(
+          authData.authenticationConfiguration
+        )} dgftSec:securityConfiguration ?srcConfg.
         ?srcConfg ?srcConfP ?srcConfO.
-        ${sparqlEscapeUri(authData.authenticationConfiguration)} dgftSec:secrets ?srcSecrets.
+        ${sparqlEscapeUri(
+          authData.authenticationConfiguration
+        )} dgftSec:secrets ?srcSecrets.
         ?srcSecrets dgftOauth:clientId ?clientId ;
           dgftOauth:clientSecret ?clientSecret .
-          OPTIONAL { ?srcConfig dgftOauth:resource ?resource . }
+        ?srcConfig dgftSec:securityConfiguration ?scheme .
+        ?scheme wotSec:token ?token ;
+                wotSec:flow ?flow .
       }
     }`;
   } else {
     throw new Error(`Unsupported Security type ${authData.securityConfigurationType}`);
   }
 
-  await update(cloneQuery);
+  await update(cloneQueryDecrypt);
 
   return newAuthConfUri;
+}
+
+/**
+ * Encrypting the source collection authenticationConfiguration data
+ * @param {String} sourceCollectionUri
+ */
+ export async function updateSourceCollection(sourceCollectionUri) {
+  let authData;
+  const getBasicAuthInfo = `
+  ${PREFIXES}
+  SELECT DISTINCT ?user ?pass
+  WHERE {
+    ${sparqlEscapeUri(
+      sourceCollectionUri
+    )} dgftSec:targetAuthenticationConfiguration ?configuration .
+    GRAPH ?g {
+      ?configuration dgftSec:secrets ?secrets .
+      ?secrets meb:username ?user ;
+              muAccount:password ?pass .
+    }
+  }
+  `;
+  const getOauth2Info = `
+  ${PREFIXES}
+  SELECT DISTINCT ?clientId ?clientSecret ?token ?flow
+  WHERE {
+    ${sparqlEscapeUri(
+      sourceCollectionUri
+    )} dgftSec:targetAuthenticationConfiguration ?configuration .
+    GRAPH ?g {
+      ?configuration dgftSec:secrets ?secrets .
+      ?secrets dgftOauth:clientId ?clientId ;
+        dgftOauth:clientSecret ?clientSecret .
+      ?configuration dgftSec:securityConfiguration ?scheme .
+      ?scheme wotSec:token ?token ;
+              wotSec:flow ?flow .
+    }
+  }
+  `;
+
+  // Check for credential type
+  if (!authData)
+    authData = await getAuthData(sourceCollectionUri);
+
+  switch (authData.securityConfigurationType) {
+    case BASIC_AUTH:
+      const { user, pass } = parseResult(await query(getBasicAuthInfo))[0];
+      const encryptBasicAuthQuery = `
+      ${PREFIXES}
+      DELETE {
+        GRAPH ?g {
+          ?configuration dgftSec:secrets ?secrets .
+          ?secrets meb:username ?user ;
+            muAccount:password ?pass .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?configuration dgftSec:secrets ?secrets .
+          ?secrets meb:username ${sparqlEscapeString(await encrypt(user))} ;
+            muAccount:password ${sparqlEscapeString(await encrypt(pass))} .
+        }
+      }
+      WHERE {
+        ${sparqlEscapeUri(sourceCollectionUri)} dgftSec:targetAuthenticationConfiguration ?configuration .
+
+        GRAPH ?g {
+          ?configuration dgftSec:secrets ?secrets .
+          ?secrets meb:username ?user ;
+            muAccount:password ?pass .
+        }
+      }
+      `;
+      await update(encryptBasicAuthQuery);
+      break;
+    case OAUTH2:
+      const { clientId, clientSecret, token, flow } = parseResult(await query(getOauth2Info))[0];
+      const encryptOauth2Query = `
+      ${PREFIXES}
+      DELETE {
+        GRAPH ?g {
+          ?configuration dgftSec:secrets ?secrets .
+          ?secrets dgftOauth:clientId ?clientId ;
+            dgftOauth:clientSecret ?clientSecret .
+          ?configuration dgftSec:securityConfiguration ?scheme .
+          ?scheme wotSec:token ?token ;
+            wotSec:flow ?flow .
+        }
+      }
+      INSERT {
+        GRAPH ?g {
+          ?configuration dgftSec:secrets ?secrets .
+          ?secrets dgftOauth:clientId ${sparqlEscapeString(await encrypt(clientId))} ;
+            dgftOauth:clientSecret ${sparqlEscapeString(await encrypt(clientSecret))}  .
+          ?configuration dgftSec:securityConfiguration ?scheme .
+          ?scheme wotSec:token ${sparqlEscapeString(await encrypt(token))}  ;
+            wotSec:flow ${sparqlEscapeString(await encrypt(flow))}  .
+        }
+      }
+      WHERE {
+        ${sparqlEscapeUri(
+          sourceCollectionUri
+        )} dgftSec:targetAuthenticationConfiguration ?configuration .
+
+        GRAPH ?g {
+          ?configuration dgftSec:secrets ?secrets .
+          ?secrets dgftOauth:clientId ?clientId ;
+            dgftOauth:clientSecret ?clientSecret .
+          ?configuration dgftSec:securityConfiguration ?scheme .
+          ?scheme wotSec:token ?token ;
+            wotSec:flow ?flow .
+        }
+      }
+      `;
+      await update(encryptOauth2Query);
+      break;
+    default:
+      return false;
+  }
 }

--- a/lib/delta/events/new-scheduled-jobs.js
+++ b/lib/delta/events/new-scheduled-jobs.js
@@ -1,5 +1,5 @@
 import {RDF_PREDICATE, SCHEDULED_JOB_TYPE} from '../../../constants';
-import { alreadyEncryptedAuthenticationConfiguration, getCollectionFromJob, updateSourceCollection } from '../../credential-helpers';
+import { alreadyEncryptedAuthenticationConfiguration, getCollectionFromJob, hasAuth, updateSourceCollection } from '../../credential-helpers';
 import {getScheduledJob} from '../../scheduled-job';
 
 export class NewScheduledJobsEvent {
@@ -20,12 +20,14 @@ export class NewScheduledJobsEvent {
       if (!this.manager.has(subject.value)) {
         try {
           const {uri, frequency} = await getScheduledJob(subject.value);
-          // This is used to run the encryption only once
-          // If a Job is created from the scheduled one, we can assume
-          // the encryption was already done
-          if (!(await alreadyEncryptedAuthenticationConfiguration(uri))) {
-            const collectionUri = await getCollectionFromJob(uri);
-            await updateSourceCollection(collectionUri.collectionUri);
+          if(hasAuth(uri)) {
+            // This is used to run the encryption only once
+            // If a Job is created from the scheduled one, we can assume
+            // the encryption was already done
+            if (!(await alreadyEncryptedAuthenticationConfiguration(uri))) {
+              const collectionUri = await getCollectionFromJob(uri);
+              await updateSourceCollection(collectionUri.collectionUri);
+            }
           }
           this.manager.add(uri, frequency).start();
           // TODO remove verbose logging

--- a/lib/delta/events/new-scheduled-jobs.js
+++ b/lib/delta/events/new-scheduled-jobs.js
@@ -1,4 +1,5 @@
 import {RDF_PREDICATE, SCHEDULED_JOB_TYPE} from '../../../constants';
+import { alreadyEncryptedAuthenticationConfiguration, getCollectionFromJob, updateSourceCollection } from '../../credential-helpers';
 import {getScheduledJob} from '../../scheduled-job';
 
 export class NewScheduledJobsEvent {
@@ -19,6 +20,13 @@ export class NewScheduledJobsEvent {
       if (!this.manager.has(subject.value)) {
         try {
           const {uri, frequency} = await getScheduledJob(subject.value);
+          // This is used to run the encryption only once
+          // If a Job is created from the scheduled one, we can assume
+          // the encryption was already done
+          if (!(await alreadyEncryptedAuthenticationConfiguration(uri))) {
+            const collectionUri = await getCollectionFromJob(uri);
+            await updateSourceCollection(collectionUri.collectionUri);
+          }
           this.manager.add(uri, frequency).start();
           // TODO remove verbose logging
           console.info(`DeltaEvent: started ${uri} [${frequency}]`);

--- a/lib/harvesting-collection.js
+++ b/lib/harvesting-collection.js
@@ -3,6 +3,7 @@ import { sparqlEscapeString, sparqlEscapeUri } from 'mu';
 import { v4 as uuid } from 'uuid';
 import { PREFIXES } from '../constants';
 import { parseResult } from '../utils/parseResult';
+import { attachClonedAuthenticationConfiguraton } from './credential-helpers';
 import { createRemoteDataObjectFromTemplate } from './remote-data-object';
 
 export async function createHarvestingCollectionFromTemplate(sourceCollectionUri){
@@ -52,5 +53,6 @@ export async function createHarvestingCollectionFromTemplate(sourceCollectionUri
   `;
 
   await update(queryStr);
+  await attachClonedAuthenticationConfiguraton(harvestingCollectionUri, sourceCollectionUri)
   return harvestingCollectionUri;
 }

--- a/lib/scheduled-job.js
+++ b/lib/scheduled-job.js
@@ -4,7 +4,6 @@ import {querySudo as query} from '@lblod/mu-auth-sudo';
 import {CRON_TIMEZONE, PREFIXES} from '../constants';
 import {parseResult} from '../utils/parseResult';
 import {createJobFromScheduledJob} from './job';
-import { getCollectionFromJob, alreadyEncryptedAuthenticationConfiguration, updateSourceCollection } from './credential-helpers';
 
 export class ScheduledJob {
 
@@ -78,13 +77,6 @@ export class ScheduledJob {
    */
   async run() {
     try {
-      // This is used to run the encryption only once
-      // If a Job is created from the scheduled one, we can assume
-      // the encryption was already done
-      if (!(await alreadyEncryptedAuthenticationConfiguration(this.uri))) {
-      const collectionUri = await getCollectionFromJob(this.uri);
-      await updateSourceCollection(collectionUri.collectionUri);
-      }
       console.info(`ScheduledJob: Executing ${this.uri} [${this.frequency}]`);
       const metadata = await getScheduledJobData({uri: this.uri});
       if (!metadata) {

--- a/lib/scheduled-job.js
+++ b/lib/scheduled-job.js
@@ -4,7 +4,7 @@ import {querySudo as query} from '@lblod/mu-auth-sudo';
 import {CRON_TIMEZONE, PREFIXES} from '../constants';
 import {parseResult} from '../utils/parseResult';
 import {createJobFromScheduledJob} from './job';
-import { getCollectionFromJob, isNormalJobCreatedFromScheduledJob, updateSourceCollection } from './credential-helpers';
+import { getCollectionFromJob, alreadyEncryptedAuthenticationConfiguration, updateSourceCollection } from './credential-helpers';
 
 export class ScheduledJob {
 
@@ -81,7 +81,7 @@ export class ScheduledJob {
       // This is used to run the encryption only once
       // If a Job is created from the scheduled one, we can assume
       // the encryption was already done
-      if (!(await isNormalJobCreatedFromScheduledJob(this.uri))) {
+      if (!(await alreadyEncryptedAuthenticationConfiguration(this.uri))) {
       const collectionUri = await getCollectionFromJob(this.uri);
       await updateSourceCollection(collectionUri.collectionUri);
       }

--- a/lib/scheduled-job.js
+++ b/lib/scheduled-job.js
@@ -4,6 +4,7 @@ import {querySudo as query} from '@lblod/mu-auth-sudo';
 import {CRON_TIMEZONE, PREFIXES} from '../constants';
 import {parseResult} from '../utils/parseResult';
 import {createJobFromScheduledJob} from './job';
+import { getCollectionFromJob, isNormalJobCreatedFromScheduledJob, updateSourceCollection } from './credential-helpers';
 
 export class ScheduledJob {
 
@@ -77,6 +78,13 @@ export class ScheduledJob {
    */
   async run() {
     try {
+      // This is used to run the encryption only once
+      // If a Job is created from the scheduled one, we can assume
+      // the encryption was already done
+      if (!(await isNormalJobCreatedFromScheduledJob(this.uri))) {
+      const collectionUri = await getCollectionFromJob(this.uri);
+      await updateSourceCollection(collectionUri.collectionUri);
+      }
       console.info(`ScheduledJob: Executing ${this.uri} [${this.frequency}]`);
       const metadata = await getScheduledJobData({uri: this.uri});
       if (!metadata) {

--- a/utils/encrypt-credentials.js
+++ b/utils/encrypt-credentials.js
@@ -1,0 +1,17 @@
+import crypto from 'crypto';
+
+const algorithm = 'aes-256-cbc';
+
+export async function encrypt(data) {
+  const cipher = crypto.createCipheriv(algorithm, process.env.SECRET_KEY, process.env.IV);
+  let encrypted = cipher.update(data, 'utf8', 'hex');
+  encrypted += cipher.final('hex');
+  return encrypted;
+}
+
+export async function decrypt(data) {
+  const decipher = crypto.createDecipheriv(algorithm, process.env.SECRET_KEY, process.env.IV);
+  let decrypted = decipher.update(data, 'hex', 'utf8');
+  decrypted += decipher.final('utf8');
+  return decrypted;
+}


### PR DESCRIPTION
# Description
DL-5039

This PR is about fixing the scheduled jobs so they can run authenticated jobs.

- Ensures the source collection (scheduled job) is properly cloned to the clone collection (normal job) so it can share the authentication configuration informations. **DONE**
- Deletes the source collection authentication configuration content when the scheduled job is deleted. **DONE**
- Adds encryption/decrytion for the authentication configuration. **DONE**


## Context 

There is cases where we need to harvest data from vendors, they're usually using an authentication mechanism. We need this feature to pass the credentials when a job is created from a scheduled job. 

What service does now  : 
- The scheduled job will serve as template to make a clone (normal job), meaning the source collection (from the scheduled job) containing authentication configuration relationship is attached to the normal job's collection.

# Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

# Related services

- [app-worship-harvester](https://github.com/lblod/app-worship-harvester)
- [scheduled-job-controller-service](https://github.com/lblod/scheduled-job-controller-service)
- [frontend-harvesting-self-service](https://github.com/lblod/frontend-harvesting-self-service)

# How to test

`app-worship-harvester` needs authentication.

Please make sure you have in your migration folder : 2023/local/`20230309104958-add-mock-user.sparql`.
You can find this migration on the development server from the `app-worship-harvester-qa`. Also you need to enable from the frontend container the variable `EMBER_AUTHENTICATION_ENABLED: 'true'`

You will need to create a docker-compose.override.yml file with the following image : `poltergeistz/scheduled-job-controller-service-local:latest`

Here's a base you can follow :

```yml
version: "3.7"

services:
  frontend:
      image: lblod/frontend-harvesting-self-service:2.0.0
      environment:
        EMBER_AUTHENTICATION_ENABLED: 'true'
  scheduled-job-controller-service:
      image: poltergeistz/scheduled-job-controller-service-local:latest
      environment:
        SECRET_KEY: ""
        IV: ""
``` 

For the `SECRET_KEY` and `IV` you can set any values you want but it has to be 32 (SECRET_KEY) and 16 (IV) character long.

For the login information it should be the same as QA.

You can now start the app and login.

## What to check

- When creating a new scheduled job, check from the source collection if the authentication configuration has encrypted data. You can use the yasgui with this query to check. You can copy the authentication configuration uri from the scheduled job you've created in ember inspector to then paste it into the query. :heavy_check_mark: 

BASIC_AUTH

```sparql
PREFIX dgftSec: <http://lblod.data.gift/vocabularies/security/>
PREFIX meb: <http://rdf.myexperiment.org/ontologies/base/>
PREFIX muAccount: <http://mu.semte.ch/vocabularies/account/>
SELECT DISTINCT * WHERE {
  <REPLACE_THIS_BY_THE_AUTHENTICATION_CONFIGURATION_URI> dgftSec:secrets ?secrets .
          ?secrets meb:username ?user ;
            muAccount:password ?pass .
} 
```

OAUTH2

```sparql
PREFIX dgftSec: <http://lblod.data.gift/vocabularies/security/>
PREFIX dgftOauth: <http://kanselarij.vo.data.gift/vocabularies/oauth-2.0-session/>
PREFIX wotSec: <https://www.w3.org/2019/wot/security#>
SELECT DISTINCT * WHERE {
   <REPLACE_THIS_BY_THE_AUTHENTICATION_CONFIGURATION_URI> dgftSec:secrets ?secrets .
          ?secrets dgftOauth:clientId ?clientId ;
            dgftOauth:clientSecret ?clientSecret .
   <REPLACE_THIS_BY_THE_AUTHENTICATION_CONFIGURATION_URI> dgftSec:securityConfiguration ?scheme .
         ?scheme wotSec:token ?token ;
            wotSec:flow ?flow .
}
```

- When the scheduled job is created check if the job is successfull for both oauth2 and basic auth. :heavy_check_mark: 
- When deleting a scheduled job the authentication configuation from the source collection should not contain any credentials data. :heavy_check_mark: 

# Links to other PR's

- https://github.com/lblod/frontend-harvesting-self-service/pull/27