### PR TITLE
Vendor provenance

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM semtech/mu-javascript-template:1.7.0
+FROM semtech/mu-javascript-template:1.8.0
 LABEL maintainer="info@redpencil"
 ENV SUDO_QUERY_RETRY="true"
 ENV SUDO_QUERY_RETRY_FOR_HTTP_STATUS_CODES="404,500,503"

--- a/lib/job.js
+++ b/lib/job.js
@@ -19,6 +19,9 @@ export async function createJobFromScheduledJob(scheduledJob) {
 
   const scheduledTask = await loadScheduledTask(scheduledJob.scheduledTasks[0]);
 
+  const vendorTriple = scheduledJob.vendor
+    ? `${sparqlEscapeUri(jobUri)} prov:wasAssociatedWith ${sparqlEscapeUri(scheduledJob.vendor)} .`
+    : '';
   const newJobQuery = `
     ${PREFIXES}
     INSERT DATA {
@@ -30,6 +33,7 @@ export async function createJobFromScheduledJob(scheduledJob) {
               dct:created ${sparqlEscapeDateTime(now)};
               dct:modified ${sparqlEscapeDateTime(now)};
               task:operation ${sparqlEscapeUri(scheduledJob.operation)}.
+        ${vendorTriple}
       }
     }
   `;

--- a/lib/scheduled-job.js
+++ b/lib/scheduled-job.js
@@ -97,7 +97,7 @@ export class ScheduledJob {
 export async function getScheduledJobData(scheduledJob) {
   const scheduledJobDataQuery = `
 ${PREFIXES}
-SELECT DISTINCT ?graph ?uri ?uuid ?schedule ?operation ?scheduledTasks WHERE {
+SELECT DISTINCT ?graph ?uri ?uuid ?schedule ?operation ?scheduledTasks ?vendor WHERE {
     BIND(${sparqlEscapeUri(scheduledJob.uri)} as ?uri)
 
     GRAPH ?graph {
@@ -108,6 +108,10 @@ SELECT DISTINCT ?graph ?uri ?uuid ?schedule ?operation ?scheduledTasks WHERE {
 
       ?scheduledTasks a task:ScheduledTask;
         dct:isPartOf ?uri.
+
+      OPTIONAL {
+        ?uri prov:wasAssociatedWith ?vendor .
+      }
   }
 }`;
   const scheduledJobInfo = parseResult(await query(scheduledJobDataQuery));


### PR DESCRIPTION
Using scheduled Jobs is a core feature of the harvester and yet this was left untested when the first round of PR's was published on the new vendor provenance feature as proven by the fact that it didn't work at all.

This PR add some small changes that make it happen. It retrieves the vendor URI from the scheduled job and puts it on the spawned job.