### PR TITLE
allow copying predicates from scheduled job to job

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,17 @@ SELECT * WHERE {
 }
 ```
 
+# Config
+This service allows for a config file that holds a single property in a default exported object:
+```js
+{
+  jobPredicatesToCopy: ['http://mu.semte.ch/vocabularies/ext/shapeForTargets'],
+}
+```
+
+The service will copy all triples with a predicate in the list `jobPredicatesToCopy` from the scheduled job instance to the job instance that is spawned as part of the scheduling of the job.
+
+
 # Caveats/TODO's
 - The service assumes the job is stored in one graph.
 - Currently deep cloning of `nfo:DataContainer` is only limited to the containers having the predicate:

--- a/config/config.js
+++ b/config/config.js
@@ -1,3 +1,3 @@
 export default {
-  jobPredicatesToCopy: ['http://mu.semte.ch/vocabularies/ext/shapeForTargets'],
+  jobPredicatesToCopy: [],
 };

--- a/config/config.js
+++ b/config/config.js
@@ -1,0 +1,3 @@
+export default {
+  jobPredicatesToCopy: ['http://mu.semte.ch/vocabularies/ext/shapeForTargets'],
+};

--- a/lib/job.js
+++ b/lib/job.js
@@ -8,6 +8,7 @@ import { createContainerFromTemplate } from './data-container';
 import { loadScheduledTask } from './scheduled-task';
 import { createTask } from './task';
 import { parseResult } from '../utils/parseResult';
+import config from '../config/config';
 
 export async function countBusyJobs() {
   const countQuery = `
@@ -46,20 +47,30 @@ export async function createJobFromScheduledJob(scheduledJob) {
     storageTriple = `${sparqlEscapeUri(jobUri)} task:storagePath ${sparqlEscapeString(path)} .`;
 
   }
+
+  const {predicatesToCopyFilter, predicatesToCopyInsert} = buildPredicatesToCopy(jobUri);
+
   const newJobQuery = `
     ${PREFIXES}
-    INSERT DATA {
+    INSERT {
       GRAPH ${sparqlEscapeUri(scheduledJob.graph)} {
         ${sparqlEscapeUri(jobUri)} a cogs:Job;
               mu:uuid ${sparqlEscapeString(jobId)};
               adms:status ${sparqlEscapeUri(STATUS_BUSY)};
-              dct:creator ${sparqlEscapeUri(scheduledJob.uri)};
+              dct:creator ?scheduledJob;
               dct:created ${sparqlEscapeDateTime(now)};
               dct:modified ${sparqlEscapeDateTime(now)};
               task:operation ${sparqlEscapeUri(scheduledJob.operation)}.
         ${vendorTriple}
         ${storageTriple}
+        ${predicatesToCopyInsert}
       }
+    } WHERE {
+      VALUES ?scheduledJob {
+        ${sparqlEscapeUri(scheduledJob.uri)}
+      }
+      ?scheduledJob a cogs:ScheduledJob .
+      ${predicatesToCopyFilter}
     }
   `;
   await update(newJobQuery);
@@ -77,4 +88,29 @@ export async function createJobFromScheduledJob(scheduledJob) {
                     STATUS_SCHEDULED,
                     [],
                     clonedContainers);
+}
+
+function buildPredicatesToCopy(jobUri){
+  const predicatesToCopy = config.jobPredicatesToCopy;
+  if(!predicatesToCopy || predicatesToCopy.length < 1){
+    return {
+      predicatesToCopyFilter: "",
+      predicatesToCopyInsert: "",
+    }
+  }
+
+  const safePredicateValues = predicatesToCopy.map(sparqlEscapeUri).join("\n")
+  return {
+    predicatesToCopyFilter: `
+      VALUES ?p {
+        ${safePredicateValues}
+      }
+      OPTIONAL {
+        ?scheduledJob ?p ?o.
+      }
+    `,
+    predicatesToCopyInsert: `
+      ${sparqlEscapeUri(jobUri)} ?p ?o.
+    `
+  }
 }


### PR DESCRIPTION
allow copying predicates from scheduled job to job, see readme for more information

Can be tested by creating a scheduled annotation job in the decide stack and verifying that the predicates on the scheduled job are indeed also present on the spawned job, see PR: https://github.com/lblod/app-decide/pull/149